### PR TITLE
select-schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.4.4
 
 - `select-schema` works with special key predicates (like regexp-keys):
+- remove `safe-coercer`
 
 ```clojure
 (st/select-schema

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## 0.4.4
+
+- `select-schema` works with special key predicates (like regexp-keys):
+
+```clojure
+(st/select-schema
+  {(s/pred #(re-find #"x-" (name %)) ":x-.*") s/Any, :a String}
+  {:x-kikka "x-kikka"
+   :x-kukka "x-kukka"
+   :y-kikka "invalid key"
+   :a "a"
+   :z "disallowed key"
+   :b "isallowed key"})
+; {:a "a", :x-kikka "x-kikka", :x-kukka "x-kukka"}
+```
+
+- updated deps:
+
+```clojure
+[codox "0.8.13"] is available but we use "0.8.12"
+```
+
 ## 0.4.3 (11.6.2015)
 
 - `select-schema` takes now optional coercion matcher - to coerce values safely in a single sweep

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,24 +1,37 @@
-## 0.4.4
+## 0.5.0
 
-- `select-schema` works with special key predicates (like regexp-keys):
 - remove `safe-coercer`
+- new `map-filter-matcher` to strip illegal keys from non-record maps
+  - original code by [abp](https://gist.github.com/abp/0c4106eba7b72802347b)
+- **breaking**: `select-schema` is dropped in favor of `select-schema!`
+  - `select-schema!` uses schema coercion (`map-filter-matcher`) to drop illegal keys
+    - fixes [#4](https://github.com/metosin/schema-tools/issues/4) - works now also with predicate keys
+    - if a value can't be coerced, Exception is thrown - just like from `schema.core/validate`
 
 ```clojure
-(st/select-schema
+(st/select-schema!
   {(s/pred #(re-find #"x-" (name %)) ":x-.*") s/Any, :a String}
-  {:x-kikka "x-kikka"
-   :x-kukka "x-kukka"
-   :y-kikka "invalid key"
-   :a "a"
+  {:a "a"
    :z "disallowed key"
-   :b "isallowed key"})
+   :b "disallowed key"
+   :x-kikka "x-kikka"
+   :x-kukka "x-kukka"
+   :y-kikka "invalid key"})
 ; {:a "a", :x-kikka "x-kikka", :x-kukka "x-kukka"}
 ```
 
-- updated deps:
-
 ```clojure
-[codox "0.8.13"] is available but we use "0.8.12"
+(st/select-schema! {:beer (s/enum :ipa :apa)} {:beer "ipa" :taste "good"})
+; clojure.lang.ExceptionInfo: Value does not match schema: {:beer (not (#{:ipa :apa} "ipa"))}
+;     data: {:type :schema.core/error,
+;            :schema {:beer {:vs #{:ipa :apa}}},
+;            :value {:beer "ipa", :taste "good"},
+;            :error {:beer (not (#{:ipa :apa} "ipa"))}}
+           
+(require '[schema.coerce :as sc])
+
+(st/select-schema! sc/json-coercion-matcher {:beer (s/enum :ipa :apa)} {:beer "ipa" :taste "good"})
+; {:beer :ipa}
 ```
 
 ## 0.4.3 (11.6.2015)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Common utilities for working with [Prismatic Schema](https://github.com/Prismatic/schema) Maps, both Clojure & ClojureScript.
 * common Schema definitions: `any-keys`, `any-keyword-keys`
-* schema-aware selectors: `get-in`, `select-keys`, `select-schema!`
+* schema-aware selectors: `get-in`, `select-keys`, `select-schema`
 * schema-aware transformers: `assoc`, `dissoc`, `assoc-in`, `update-in`, `update`, `dissoc-in`, `merge`, `optional-keys`, `required-keys`
   * removes the schema name and ns if the schema (value) has changed.
 * meta-data helpers: `schema-with-description` `schema-description`, `resolve-schema` (clj only), `resolve-schema-description` (clj only)
@@ -47,23 +47,28 @@ With schema-tools:
 ; nil
 ```
 
-### select-schema!
+### select-schema
 
 Filtering out illegal keys using coercion:
 
 ```clojure
-(st/select-schema! Address {:street "Keskustori 8"
-                            :city "Tampere"
-                            :description "Metosin HQ" ; disallowed-key
-                            :country {:weather "-18" ; disallowed-key
-                                      :name "Finland"}})
+(st/select-schema {:street "Keskustori 8"
+                   :city "Tampere"
+                   :description "Metosin HQ" ; disallowed-key
+                   :country {:weather "-18" ; disallowed-key
+                             :name "Finland"}}
+                  Address)
 ; {:city "Tampere", :street "Keskustori 8", :country {:name "Finland"}}
 ```
 
 Json-coercion with filtering out illegal keys in a single sweep:
 
 ```clojure
-(st/select-schema! {:beer (s/enum :ipa :apa)} {:beer "ipa" :taste "good"})
+(s/defschema Beer {:beer (s/enum :ipa :apa)})
+
+(def ipa {:beer "ipa" :taste "good"})
+
+(st/select-schema ipa Beer)
 ; clojure.lang.ExceptionInfo: Value does not match schema: {:beer (not (#{:ipa :apa} "ipa"))}
 ;     data: {:type :schema.core/error,
 ;            :schema {:beer {:vs #{:ipa :apa}}},
@@ -72,7 +77,7 @@ Json-coercion with filtering out illegal keys in a single sweep:
            
 (require '[schema.coerce :as sc])
 
-(st/select-schema! sc/json-coercion-matcher {:beer (s/enum :ipa :apa)} {:beer "ipa" :taste "good"})
+(st/select-schema ipa Beer sc/json-coercion-matcher)
 ; {:beer :ipa}
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ Normal `clojure.core` functions don't work well with Schemas:
                       (s/optional-key :city) s/Str
                       (s/required-key :country) {:name s/Str}})
 
-
 ;; where's my city?
 (select-keys Address [:street :city])
-; => {:street java.lang.String}
+; {:street java.lang.String}
 
 ; this should not return the original Schema name...
 (s/schema-name (select-keys Address [:street :city]))
-; => Address
+; Address
 ```
 
 With schema-tools:
@@ -42,12 +41,12 @@ With schema-tools:
 (require '[schema-tools.core :as st])
 
 (st/select-keys Address [:street :city])
-; => {:street java.lang.String, #schema.core.OptionalKey{:k :city} java.lang.String}
+; {:street java.lang.String, #schema.core.OptionalKey{:k :city} java.lang.String}
 
 (s/schema-name (st/select-keys Address [:street :city]))
 ; nil
+```
 
-````
 
 Filtering out extra keys (without validation errors):
 
@@ -62,7 +61,7 @@ Filtering out extra keys (without validation errors):
 
 ## Usage
 
-See the [tests](https://github.com/metosin/schema-tools/blob/master/test/schema_tools/core_test.cljx).
+See the [tests](https://github.com/metosin/schema-tools/tree/master/test/schema_tools).
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/schema-tools "0.4.3"
+(defproject metosin/schema-tools "0.5.0-SNAPSHOT"
   :description "Common utilities for Prismatic Schema"
   :url "https://github.com/metosin/schema-tools"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -32,8 +32,8 @@
   :profiles {:dev {:plugins [[com.keminglabs/cljx "0.6.0"]
                              [jonase/eastwood "0.2.1"]]
                    :dependencies [[criterium "0.4.3"]
-                                  [org.clojure/clojure "1.7.0-beta3"]
+                                  [org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "0.0-3308"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :aliases {"all" ["with-profile" "dev:dev,1.7"]
             "test-clj" ["all" "do" ["cljx" "once"] ["test"] ["check"]]})

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [prismatic/schema "0.4.3"]]
-  :plugins [[codox "0.8.12"]]
+  :plugins [[codox "0.8.13"]]
 
   :cljx {:builds [{:rules :clj
                    :source-paths ["src"]

--- a/src/schema_tools/coerce.cljx
+++ b/src/schema_tools/coerce.cljx
@@ -6,26 +6,6 @@
             [schema.coerce :as sc])
   #+cljs (:require-macros [schema.macros :as sm]))
 
-(defn safe-coercer
-  "Produce a function that coerces a datum without validation."
-  [schema coercion-matcher]
-  (s/start-walker
-    (su/memoize-id
-      (fn [s]
-        (let [walker (s/walker s)]
-          (if-let [coercer (coercion-matcher s)]
-            (fn [x]
-              (sm/try-catchall
-                (let [v (coercer x)]
-                  (if (su/error? v)
-                    x
-                    (let [walked (walker v)]
-                      (if (su/error? walked)
-                        x
-                        walked))))
-                (catch t (sm/validation-error s x t))))
-            walker))))
-    schema))
 
 ;;
 ;; Matchers

--- a/src/schema_tools/coerce.cljx
+++ b/src/schema_tools/coerce.cljx
@@ -6,10 +6,38 @@
             [schema.coerce :as sc])
   #+cljs (:require-macros [schema.macros :as sm]))
 
+; original: https://gist.github.com/abp/0c4106eba7b72802347b
+(defn- filter-schema-keys
+  [m schema-keys extra-keys-walker]
+  (reduce-kv (fn [m k _]
+               (if (or (contains? schema-keys k)
+                       (and extra-keys-walker
+                            (not (su/error? (extra-keys-walker k)))))
+                 m
+                 (dissoc m k)))
+             m
+             m))
 
 ;;
 ;; Matchers
 ;;
+
+; original: https://gist.github.com/abp/0c4106eba7b72802347b
+(defn map-filter-matcher
+  "Creates a matcher which removes all illegal keys from non-record maps."
+  [schema]
+  (if (and (map? schema) (not (record? schema)))
+    (let [extra-keys-schema (s/find-extra-keys-schema schema)
+          extra-keys-walker (if extra-keys-schema (s/walker extra-keys-schema))
+          explicit-keys (some->> (dissoc schema extra-keys-schema)
+                                 keys
+                                 (mapv s/explicit-schema-key)
+                                 set)]
+      (if (or extra-keys-walker (seq explicit-keys))
+        (fn [x]
+          (if (map? x)
+            (filter-schema-keys x explicit-keys extra-keys-walker)
+            x))))))
 
 (defn or-matcher
   "Creates a matcher where the first matcher matching the

--- a/src/schema_tools/core.cljx
+++ b/src/schema_tools/core.cljx
@@ -49,10 +49,8 @@
             :else (f k)))
         schema))))
 
-(defn- error! [schema value error]
-  (sm/error!
-    (su/format* "Value does not match schema: %s" (pr-str error))
-    {:schema schema :value value :error error}))
+(defn- error! [message schema value error]
+  (sm/error! message {:schema schema :value value :error error}))
 
 ;;
 ;; Definitions
@@ -208,7 +206,9 @@
    (let [coercer (sc/coercer schema (stc/or-matcher stc/map-filter-matcher matcher))
          coerced (coercer value)]
      (if-let [error (and (su/error? coerced) (su/error-val coerced))]
-       (error! schema value error)
+       (error!
+         (str "Could not coerce value to schema: " (pr-str error))
+         schema value error)
        coerced))))
 
 (defn optional-keys

--- a/test/schema_tools/core_test.cljx
+++ b/test/schema_tools/core_test.cljx
@@ -2,7 +2,6 @@
   (:require #+clj [clojure.test :refer [deftest testing is]]
     #+cljs [cljs.test :as test :refer-macros [deftest testing is]]
             [schema-tools.core :as st]
-            [schema.utils :as su]
             [schema.coerce :as sc]
             [schema.core :as s :include-macros true]))
 
@@ -183,8 +182,7 @@
         (is (= (st/select-schema sc/json-coercion-matcher schema value)
                {:name "Linda" :sex :female})))))
 
-  ;; TODO: does not work.
-  #_(testing "with regexp-keys"
+  (testing "with regexp-keys"
     (let [X- (s/pred #(re-find #"x-" (name %)) ":x-.*")
           schema {X- s/Any
                   :a s/Any}

--- a/test/schema_tools/select_schema_test.cljx
+++ b/test/schema_tools/select_schema_test.cljx
@@ -28,7 +28,7 @@
       (testing "value does not match schema"
         (is (invalid? schema value)))
 
-      (testing "select-schema! drops disallowed keys making value match schema"
+      (testing "select-schema drops disallowed keys making value match schema"
         (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
           (is (= selected {:a "kikka", :b {[1 2 3] [{"d" "kukka"}]}}))))))
@@ -45,22 +45,28 @@
       (testing "value does not match schema"
         (is (invalid? schema value)))
 
-      (testing "select-schema! drops disallowed keys making value match schema"
+      (testing "select-schema drops disallowed keys making value match schema"
         (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
           (is (= selected {:kikka "kukka", :a {:b {"abba" "jabba"}, :c {[1 2 3] "kakka"}}}))))))
 
-  (testing "other errors cause schema.utils.ErrorContainer"
-    (is (thrown? clojure.lang.ExceptionInfo (st/select-schema {:a 123} {:a s/Str}))))
+  (testing "other errors cause coercion exception"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Could not coerce value to schema"
+          (st/select-schema {:a 123} {:a s/Str}))))
 
   (testing "with coercion matcher"
     (let [schema {:name s/Str, :sex (s/enum :male :female)}
           value {:name "Linda", :age 66, :sex "female"}]
 
-      (testing "select-schema! fails on type mismatch"
-        (is (thrown? clojure.lang.ExceptionInfo (st/select-schema value schema))))
+      (testing "select-schema fails on type mismatch"
+        (is (thrown-with-msg?
+              clojure.lang.ExceptionInfo
+              #"Could not coerce value to schema"
+              (st/select-schema value schema))))
 
-      (testing "select-schema! with extra coercion matcher succeeds"
+      (testing "select-schema with extra coercion matcher succeeds"
         (let [selected (st/select-schema value schema sc/json-coercion-matcher)]
           (is (valid? schema selected))
           (is (= selected {:name "Linda" :sex :female}))))))
@@ -76,7 +82,7 @@
       (testing "value does not match schema"
         (is (invalid? schema value)))
 
-      (testing "select-schema! drops disallowed keys making value match schema"
+      (testing "select-schema drops disallowed keys making value match schema"
         (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
           (is (= selected {:x-abba "kikka", :a "kakka"}))))))

--- a/test/schema_tools/select_schema_test.cljx
+++ b/test/schema_tools/select_schema_test.cljx
@@ -12,10 +12,10 @@
 (defn invalid? [schema value]
   (not (valid? schema value)))
 
-(deftest select-schema!-test
+(deftest select-schema-test
 
   (testing "simple case"
-    (is (= (st/select-schema! s/Str "kikka") "kikka")))
+    (is (= (st/select-schema "kikka" s/Str) "kikka")))
 
   (testing "strictly defined schema, with disallowed keys"
     (let [schema {:a s/Str
@@ -29,7 +29,7 @@
         (is (invalid? schema value)))
 
       (testing "select-schema! drops disallowed keys making value match schema"
-        (let [selected (st/select-schema! schema value)]
+        (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
           (is (= selected {:a "kikka", :b {[1 2 3] [{"d" "kukka"}]}}))))))
 
@@ -46,22 +46,22 @@
         (is (invalid? schema value)))
 
       (testing "select-schema! drops disallowed keys making value match schema"
-        (let [selected (st/select-schema! schema value)]
+        (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
           (is (= selected {:kikka "kukka", :a {:b {"abba" "jabba"}, :c {[1 2 3] "kakka"}}}))))))
 
   (testing "other errors cause schema.utils.ErrorContainer"
-    (is (thrown? clojure.lang.ExceptionInfo (st/select-schema! {:a s/Str} {:a 123}))))
+    (is (thrown? clojure.lang.ExceptionInfo (st/select-schema {:a 123} {:a s/Str}))))
 
   (testing "with coercion matcher"
     (let [schema {:name s/Str, :sex (s/enum :male :female)}
           value {:name "Linda", :age 66, :sex "female"}]
 
       (testing "select-schema! fails on type mismatch"
-        (is (thrown? clojure.lang.ExceptionInfo (st/select-schema! schema value))))
+        (is (thrown? clojure.lang.ExceptionInfo (st/select-schema value schema))))
 
       (testing "select-schema! with extra coercion matcher succeeds"
-        (let [selected (st/select-schema! sc/json-coercion-matcher schema value)]
+        (let [selected (st/select-schema value schema sc/json-coercion-matcher)]
           (is (valid? schema selected))
           (is (= selected {:name "Linda" :sex :female}))))))
 
@@ -77,6 +77,12 @@
         (is (invalid? schema value)))
 
       (testing "select-schema! drops disallowed keys making value match schema"
-        (let [selected (st/select-schema! schema value)]
+        (let [selected (st/select-schema value schema)]
           (is (valid? schema selected))
-          (is (= selected {:x-abba "kikka", :a "kakka"})))))))
+          (is (= selected {:x-abba "kikka", :a "kakka"}))))))
+
+  (testing "using with pre 0.5.0 argument order"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Illegal argument order - breaking change in 0.5.0."
+          (st/select-schema (s/enum :a :b) :b)))))

--- a/test/schema_tools/select_schema_test.cljx
+++ b/test/schema_tools/select_schema_test.cljx
@@ -1,0 +1,82 @@
+(ns schema-tools.select-schema-test
+  (:require #+clj [clojure.test :refer [deftest testing is]]
+    #+cljs [cljs.test :as test :refer-macros [deftest testing is]]
+            [schema-tools.core :as st]
+            [schema.coerce :as sc]
+            [schema.core :as s :include-macros true]
+            [schema.utils :as su]))
+
+(defn valid? [schema value]
+  (nil? (s/check schema value)))
+
+(defn invalid? [schema value]
+  (not (valid? schema value)))
+
+(deftest select-schema!-test
+
+  (testing "simple case"
+    (is (= (st/select-schema! s/Str "kikka") "kikka")))
+
+  (testing "strictly defined schema, with disallowed keys"
+    (let [schema {:a s/Str
+                  :b {(s/optional-key [1 2 3]) [{(s/required-key "d") s/Str}]}}
+          value {:a "kikka"
+                 :b {[1 2 3] [{"d" "kukka"
+                               ":d" "kikka"
+                               :d "kukka"}]}}]
+
+      (testing "value does not match schema"
+        (is (invalid? schema value)))
+
+      (testing "select-schema! drops disallowed keys making value match schema"
+        (let [selected (st/select-schema! schema value)]
+          (is (valid? schema selected))
+          (is (= selected {:a "kikka", :b {[1 2 3] [{"d" "kukka"}]}}))))))
+
+  (testing "loosely defined schema, with disallowed keys"
+    (let [schema {s/Keyword s/Str
+                  :a {:b {s/Str s/Str}
+                      :c {s/Any s/Str}}}
+          value {:kikka "kukka"
+                 :a {:b {"abba" "jabba"}
+                     :c {[1 2 3] "kakka"}
+                     :d :ILLEGAL-KEY}}]
+
+      (testing "value does not match schema"
+        (is (invalid? schema value)))
+
+      (testing "select-schema! drops disallowed keys making value match schema"
+        (let [selected (st/select-schema! schema value)]
+          (is (valid? schema selected))
+          (is (= selected {:kikka "kukka", :a {:b {"abba" "jabba"}, :c {[1 2 3] "kakka"}}}))))))
+
+  (testing "other errors cause schema.utils.ErrorContainer"
+    (is (thrown? clojure.lang.ExceptionInfo (st/select-schema! {:a s/Str} {:a 123}))))
+
+  (testing "with coercion matcher"
+    (let [schema {:name s/Str, :sex (s/enum :male :female)}
+          value {:name "Linda", :age 66, :sex "female"}]
+
+      (testing "select-schema! fails on type mismatch"
+        (is (thrown? clojure.lang.ExceptionInfo (st/select-schema! schema value))))
+
+      (testing "select-schema! with extra coercion matcher succeeds"
+        (let [selected (st/select-schema! sc/json-coercion-matcher schema value)]
+          (is (valid? schema selected))
+          (is (= selected {:name "Linda" :sex :female}))))))
+
+  (testing "with predicate keys"
+    (let [x- (s/pred #(re-find #"x-" (name %)) ":x-.*")
+          schema {x- s/Any
+                  :a s/Any}
+          value {:x-abba "kikka"
+                 :y-abba "kukka"
+                 :a "kakka"}]
+
+      (testing "value does not match schema"
+        (is (invalid? schema value)))
+
+      (testing "select-schema! drops disallowed keys making value match schema"
+        (let [selected (st/select-schema! schema value)]
+          (is (valid? schema selected))
+          (is (= selected {:x-abba "kikka", :a "kakka"})))))))


### PR DESCRIPTION
Current select-schema can't handle keys predicates and fails silently when the value can't be coerced fully to match the schema. 

In this PR, the internals are rewritten based on the [discussion](https://groups.google.com/forum/#!topic/prismatic-plumbing/SaOBraHzoHE) with the Prismatic guys. In addition, if a coercion fails, validation exception is thrown (identical to exception from `schema.core/validate`).

- fixes #4 
- resolves #10 

**breaking change**: `select-schema` now either a) succeeds and returns the coerced value or b) fails with an exception.

**breaking change**: argument order is changed to be coherent to other apis (supporting single-threading). Descriptive ex-info is thrown is fn is used with old argument order.