### PR TITLE
Update to schema v1.0.1 and fix breakage in map-filter-matcher

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[prismatic/schema "0.4.4"]]
+  :dependencies [[prismatic/schema "1.0.1"]]
   :plugins [[codox "0.8.13"]]
 
   :cljx {:builds [{:rules :clj


### PR DESCRIPTION
The new spec-based schema implementation got rid of the walker method on the Schema protocol. Instead, the spec method returns an object which satisfies the CoreSpec protocol. This protocol defines  a check method which fills largely the same purpose as the old walker method.

This PR updates the `map-filter-matcher` function to use the new spec-based checker function. With this change, the test suite passes cleanly using `[schema "1.0.1"]`. I'm not sure if you had additional changes in mind to support v1.0, but this at least prevents schema-tools from crashing when using > v1.0.

Let me know if you have any questions or further requested changes.