### PR TITLE
Deprecate schema as first argument to walk

### DIFF
--- a/src/schema_tools/walk.cljc
+++ b/src/schema_tools/walk.cljc
@@ -20,10 +20,6 @@
   Schema."
   {:added "0.3.0"}
   [inner outer this]
-  (let [[inner outer this] (if (and (fn? outer) (fn? this))
-                             (do (println "WARNING: Using deprecated walk argument order. Schema should be the last argument.")
-                                 [outer this inner])
-                             [inner outer this])]
   (cond
     ; Schemas with children
     (satisfies? WalkableSchema this) (-walk this inner outer)
@@ -34,7 +30,7 @@
     #?@(:clj [(list? this) (outer (with-meta (apply list (map inner this)) (meta this)))])
     (seq? this) (outer (with-meta (doall (map inner this)) (meta this)))
     (coll? this) (outer (with-meta (into (empty this) (map inner this)) (meta this)))
-    :else (outer this))))
+    :else (outer this)))
 
 (defn postwalk
   "Performs a depth-first, post-order traversal of `schema`.  Calls `f` on

--- a/test/schema_tools/experimental/walk_test.cljc
+++ b/test/schema_tools/experimental/walk_test.cljc
@@ -16,8 +16,8 @@
 
 (deftest abstract-map-test
   (let [k (atom [])]
-    (sw/walk Animal (fn [x] (swap! k conj x) x) identity)
+    (sw/walk (fn [x] (swap! k conj x) x) identity Animal)
     (is (= [Cat {:age s/Num, :vegan? s/Bool}] @k)))
   (let [k (atom [])]
-    (sw/walk Cat (fn [x] (swap! k conj x) x) identity)
+    (sw/walk (fn [x] (swap! k conj x) x) identity Cat)
     (is (= [Animal {:age s/Num, :vegan? s/Bool, :fav-catnip s/Str, :type (s/enum :cat)}] @k))))

--- a/test/schema_tools/walk_test.cljc
+++ b/test/schema_tools/walk_test.cljc
@@ -41,16 +41,6 @@
       (is (= {:a (s/maybe s/Int)}
              (replace-str {:a (s/maybe s/Str)}))))))
 
-(deftest legacy-walk-arguments-test
-  (testing "inner is called with the MapEntries"
-    (let [k (atom [])]
-      (sw/walk {:a s/Str :b s/Str}
-               (fn [x]
-                 (swap! k conj x)
-                 x)
-               identity)
-      (is (= [[:a s/Str] [:b s/Str]] @k)))))
-
 (defn map-entry? [x]
   #?(:clj  (instance? clojure.lang.IMapEntry x)
      :cljs (satisfies? IMapEntry x)))


### PR DESCRIPTION
It would make much sense to use same argument order as `clojure.walk/walk` for `schema-tools.walk/walk`.

This can be implemented as mostly non-breaking change by adding a test to `walk` to check for old order.

- This has some small(?) performance effect
- Some `inner` and `outer` arguments aren't necessary fns, but other things which implement `IFn`, but because map schemas also implement `IFn`, `fn?` must be used instead of `ifn?`