### PR TITLE
Make open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: lein2
+lein: 2.7.1
 script: ./scripts/test.sh $TEST
 env:
   matrix:
@@ -9,15 +9,12 @@ env:
 matrix:
   exclude:
     - env: TEST=cljs
-      jdk: openjdk6
-    - env: TEST=cljs
       jdk: openjdk7
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk8
 node_js:
-  - "0.10"
+  - "6.1"
 cache:
   directories:
   - "$HOME/.m2"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Added `st/make-open` to make Map Schemas accept any extra keys (if no specific key was set)
 - Tested also against `[org.clojure/clojurescript "1.9.946"]` & `[org.clojure/clojure "1.9.0-beta2"]`
 - Updated dependencies:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-## Unreleased
+## 0.9.1-SNAPSHOT
 
-- Added `st/make-open` to make Map Schemas accept any extra keys
+- `st/open-schema` transforms all nested Map Schemas to accept any extra keys
 - Tested also against `[org.clojure/clojurescript "1.9.946"]` & `[org.clojure/clojure "1.9.0-beta2"]`
 - Updated dependencies:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
-- Tested with `[org.clojure/clojurescript "1.9.562"]`
+- Tested also against `[org.clojure/clojurescript "1.9.946"]` & `[org.clojure/clojure "1.9.0-beta2"]`
 - Updated dependencies:
 
 ```clj
-[prismatic/schema "1.1.6"] is available but we use "1.0.5"
+[prismatic/schema "1.1.7"] is available but we use "1.0.5"
+[org.clojure/clojurescript "1.9.946"] is available but we use "1.9.562"
 ```
 
 ## 0.9.0 (20.4.2016)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.9.1-SNAPSHOT
 
+- `stc/corce` and `stc/coercer` default to `(constantly nil)` matcher
 - `st/open-schema` transforms all nested Map Schemas to accept any extra keys
 - Tested also against `[org.clojure/clojurescript "1.9.946"]` & `[org.clojure/clojure "1.9.0-beta2"]`
 - Updated dependencies:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Added `st/make-open` to make Map Schemas accept any extra keys (if no specific key was set)
+- Added `st/make-open` to make Map Schemas accept any extra keys
 - Tested also against `[org.clojure/clojurescript "1.9.946"]` & `[org.clojure/clojure "1.9.0-beta2"]`
 - Updated dependencies:
 

--- a/project.clj
+++ b/project.clj
@@ -5,17 +5,17 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[prismatic/schema "1.1.6"]]
+  :dependencies [[prismatic/schema "1.1.7"]]
   :plugins [[funcool/codeina "0.5.0"]]
 
   :codeina {:target "doc"
             :src-uri "http://github.com/metosin/schema-tools/blob/master/"
             :src-uri-prefix "#L"}
 
-  :profiles {:dev {:plugins [[jonase/eastwood "0.2.4"]]
+  :profiles {:dev {:plugins [[jonase/eastwood "0.2.5"]]
                    :dependencies [[criterium "0.4.4"]
                                   [org.clojure/clojure "1.8.0"]
-                                  [org.clojure/clojurescript "1.9.562"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.7"]
+                                  [org.clojure/clojurescript "1.9.946"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta2"]]}}
+  :aliases {"all" ["with-profile" "dev:dev,1.9"]
             "test-clj" ["all" "do" ["test"] ["check"]]})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/schema-tools "0.9.0"
+(defproject metosin/schema-tools "0.9.1-SNAPSHOT"
   :description "Common utilities for Prismatic Schema"
   :url "https://github.com/metosin/schema-tools"
   :license {:name "Eclipse Public License"

--- a/src/schema_tools/coerce.cljc
+++ b/src/schema_tools/coerce.cljc
@@ -40,16 +40,16 @@
   "Creates a matcher which removes all illegal keys from non-record maps."
   [schema]
   (when (and (map? schema) (not (record? schema)))
-    (let [extra-keys-schema  (s/find-extra-keys-schema schema)
+    (let [extra-keys-schema (s/find-extra-keys-schema schema)
           extra-keys-checker (when extra-keys-schema
                                (ss/run-checker (fn [s params]
                                                  (ss/checker (s/spec s) params))
                                                true
                                                extra-keys-schema))
-          explicit-keys      (some->> (dissoc schema extra-keys-schema)
-                                      keys
-                                      (mapv s/explicit-schema-key)
-                                      set)]
+          explicit-keys (some->> (dissoc schema extra-keys-schema)
+                                 keys
+                                 (mapv s/explicit-schema-key)
+                                 set)]
       (when (or extra-keys-checker (seq explicit-keys))
         (fn [x]
           (if (map? x)
@@ -107,6 +107,8 @@
   "Produce a function that simultaneously coerces and validates a value against a `schema.`
   If a value can't be coerced to match the schema, an `ex-info` is thrown - like `schema.core/validate`,
   but with overridable `:type`, defaulting to `:schema-tools.coerce/error.`"
+  ([schema]
+   (coercer schema (constantly nil)))
   ([schema matcher]
    (coercer schema matcher ::error))
   ([schema matcher type]
@@ -118,7 +120,9 @@
   "Simultaneously coerces and validates a value to match the given `schema.` If a `value` can't
   be coerced to match the `schema`, an `ex-info` is thrown - like `schema.core/validate`,
   but with overridable `:type`, defaulting to `:schema-tools.coerce/error.`"
+  ([value schema]
+   (coerce value schema (constantly nil)))
   ([value schema matcher]
-    (coerce value schema matcher ::error))
+   (coerce value schema matcher ::error))
   ([value schema matcher type]
    ((coercer schema matcher type) value)))

--- a/src/schema_tools/core.cljc
+++ b/src/schema_tools/core.cljc
@@ -217,7 +217,7 @@
   ([value schema matcher]
    (stc/coerce value schema (stc/or-matcher stc/map-filter-matcher matcher))))
 
-(defn make-open
+(defn open-schema
   "Walks a schema adding [`s/Any` `s/Any`] entry to all Map Schemas, removing any
   existing extra keys if defined."
   [schema]

--- a/src/schema_tools/core.cljc
+++ b/src/schema_tools/core.cljc
@@ -218,14 +218,15 @@
    (stc/coerce value schema (stc/or-matcher stc/map-filter-matcher matcher))))
 
 (defn make-open
-  "Walks a schema adding [`s/Any` `s/Any`] entry all Map Schemas if they don't
-  have a spesific key already defined."
+  "Walks a schema adding [`s/Any` `s/Any`] entry to all Map Schemas, removing any
+  existing extra keys if defined."
   [schema]
   (walk/prewalk
     (fn [x]
       (if (and (map? x) (not (record? x)))
-        (if-not (s/find-extra-keys-schema x)
-          (assoc x s/Any s/Any))
+        (-> x
+            (dissoc (s/find-extra-keys-schema x))
+            (assoc s/Any s/Any))
         x))
     schema))
 

--- a/src/schema_tools/core.cljc
+++ b/src/schema_tools/core.cljc
@@ -2,6 +2,7 @@
   (:require [schema.core :as s]
             [schema-tools.coerce :as stc]
             [schema-tools.util :as stu]
+            [schema-tools.walk :as walk]
             [schema-tools.core.impl :as impl])
   (:refer-clojure :exclude [assoc dissoc select-keys update get-in assoc-in update-in merge]))
 
@@ -215,6 +216,18 @@
    (select-schema value schema (constantly nil)))
   ([value schema matcher]
    (stc/coerce value schema (stc/or-matcher stc/map-filter-matcher matcher))))
+
+(defn make-open
+  "Walks a schema adding [`s/Any` `s/Any`] entry all Map Schemas if they don't
+  have a spesific key already defined."
+  [schema]
+  (walk/prewalk
+    (fn [x]
+      (if (and (map? x) (not (record? x)))
+        (if-not (s/find-extra-keys-schema x)
+          (assoc x s/Any s/Any))
+        x))
+    schema))
 
 (defn optional-keys
   "Makes given map keys optional. Defaults to all keys."

--- a/src/schema_tools/core.cljc
+++ b/src/schema_tools/core.cljc
@@ -224,9 +224,7 @@
   (walk/prewalk
     (fn [x]
       (if (and (map? x) (not (record? x)))
-        (-> x
-            (dissoc (s/find-extra-keys-schema x))
-            (assoc s/Any s/Any))
+        (assoc (dissoc x (s/find-extra-keys-schema x)) s/Any s/Any)
         x))
     schema))
 

--- a/test/schema_tools/coerce_test.cljc
+++ b/test/schema_tools/coerce_test.cljc
@@ -89,6 +89,9 @@
 
 (deftest coercer-test
 
+  (testing "1-arity just for validating"
+    (is (= "kikka" ((stc/coercer s/Str) "kikka"))))
+
   (testing "default case"
 
     (let [matcher {s/Str #(if (string? %) (string/upper-case %) %)}

--- a/test/schema_tools/core_test.cljc
+++ b/test/schema_tools/core_test.cljc
@@ -68,9 +68,9 @@
     (is (nil? (meta (st/select-keys Kikka [:a]))))))
 
 (deftest open-schema-test
-  (let [schema {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}
+  (let [schema {:a s/Int, :b [(s/maybe {:a s/Int, s/Keyword s/Keyword})]}
         value {:a 1, :b [{:a 1, "kikka" "kukka"}], "kukka" "kakka"}]
-    (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
+    (is (= {:a s/Int, :b [(s/maybe {:a s/Int, s/Any s/Any})], s/Any s/Any}
            (st/open-schema schema)))
     (is (= value ((stc/coercer (st/open-schema schema)) value)))))
 

--- a/test/schema_tools/core_test.cljc
+++ b/test/schema_tools/core_test.cljc
@@ -67,6 +67,10 @@
     (is (not (nil? (meta (st/select-keys Kikka [:a :b])))))
     (is (nil? (meta (st/select-keys Kikka [:a]))))))
 
+(deftest make-open-test
+  (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
+        (st/make-open {:a Long, :b [(s/maybe {:a Long})]}))))
+
 (def get-in-schema
   {:a {(s/optional-key :b) {(s/required-key :c) s/Str}}
    (s/optional-key "d") {s/Keyword s/Str}})

--- a/test/schema_tools/core_test.cljc
+++ b/test/schema_tools/core_test.cljc
@@ -69,7 +69,7 @@
 
 (deftest make-open-test
   (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
-        (st/make-open {:a Long, :b [(s/maybe {:a Long})]}))))
+        (st/make-open {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}))))
 
 (def get-in-schema
   {:a {(s/optional-key :b) {(s/required-key :c) s/Str}}

--- a/test/schema_tools/core_test.cljc
+++ b/test/schema_tools/core_test.cljc
@@ -67,9 +67,9 @@
     (is (not (nil? (meta (st/select-keys Kikka [:a :b])))))
     (is (nil? (meta (st/select-keys Kikka [:a]))))))
 
-(deftest make-open-test
+(deftest open-schema-test
   (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
-        (st/make-open {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}))))
+         (st/open-schema {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}))))
 
 (def get-in-schema
   {:a {(s/optional-key :b) {(s/required-key :c) s/Str}}

--- a/test/schema_tools/core_test.cljc
+++ b/test/schema_tools/core_test.cljc
@@ -68,8 +68,11 @@
     (is (nil? (meta (st/select-keys Kikka [:a]))))))
 
 (deftest open-schema-test
-  (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
-         (st/open-schema {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}))))
+  (let [schema {:a Long, :b [(s/maybe {:a Long, s/Keyword s/Keyword})]}
+        value {:a 1, :b [{:a 1, "kikka" "kukka"}], "kukka" "kakka"}]
+    (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
+           (st/open-schema schema)))
+    (is (= value ((stc/coercer (st/open-schema schema)) value)))))
 
 (def get-in-schema
   {:a {(s/optional-key :b) {(s/required-key :c) s/Str}}


### PR DESCRIPTION
Some say think Spec is better than Schema as the KeySets are open.

* `st/coerce` could take optional options map with `:open?` as an option
* should the `:open` override the existing special keys? => YES.
* maybe we should support both? (override & add-if-no-special-key-present) => NO

```clj
(deftest make-open-test
  (is (= {:a Long, :b [(s/maybe {:a Long, s/Any s/Any})], s/Any s/Any}
        (st/make-open {:a Long, :b [(s/maybe {:a Long})]}))))
```