### PR TITLE
Default key matcher

### DIFF
--- a/src/schema_tools/coerce.cljc
+++ b/src/schema_tools/coerce.cljc
@@ -66,13 +66,17 @@
             x))))))
 
 ; original: https://groups.google.com/forum/m/#!topic/prismatic-plumbing/NWUnqbYhfac
-(defn default-coercion-matcher
+(defn default-value-matcher
   "Creates a matcher which converts nils to default values. You can set default values
   with [[schema-tools.core/default]]."
   [schema]
   (when (impl/default? schema)
     (fn [value]
       (if (nil? value) (:value schema) value))))
+
+(def ^:deprecated default-coercion-matcher
+  "Deprecated - use [[default-value-matcher]] instead."
+  default-value-matcher)
 
 (defn default-key-matcher
   "Creates a matcher which adds missing keys to a map if they have default values.

--- a/src/schema_tools/coerce.cljc
+++ b/src/schema_tools/coerce.cljc
@@ -66,10 +66,29 @@
             x))))))
 
 ; original: https://groups.google.com/forum/m/#!topic/prismatic-plumbing/NWUnqbYhfac
-(defn default-coercion-matcher [schema]
+(defn default-coercion-matcher
+  "Creates a matcher which converts nils to default values. You can set default values
+  with [[schema-tools.core/default]]."
+  [schema]
   (when (impl/default? schema)
     (fn [value]
       (if (nil? value) (:value schema) value))))
+
+(defn default-key-matcher
+  "Creates a matcher which adds missing keys to a map if they have default values.
+  You can set default values with [[schema-tools.core/default]]."
+  [schema]
+  ;; Can't use `map?` here, since we're looking for a map literal, but records
+  ;; satisfy `map?`.
+  (when (and (map? schema) (not (record? schema)))
+    (let [default-map (reduce-kv (fn [acc k v]
+                                   (if (impl/default? v)
+                                     (assoc acc k (:value v))
+                                     acc))
+                                 {}
+                                 schema)]
+      (when (seq default-map)
+        (fn [x] (merge default-map x))))))
 
 (defn multi-matcher
   "Creates a matcher for (accept-schema schema), reducing

--- a/test/cljc/schema_tools/core_test.cljc
+++ b/test/cljc/schema_tools/core_test.cljc
@@ -248,6 +248,18 @@
       (is (= {:a "a"} (coerce {:a nil})))
       (is (= {:a "a", :b [{:c 42}]} (coerce {:a nil :b [{:c nil}]}))))))
 
+(deftest default-key-test
+  (let [schema {:a (st/default s/Str "a")
+                (s/optional-key :b)
+                [{:c (st/default s/Int 42)}]}
+        coerce (sc/coercer! schema stc/default-key-matcher)]
+    (testing "missing keys are added"
+      (is (= {:a "a"} (coerce {})))
+      (is (= {:a "b"} (coerce {:a "b"})))
+      (is (= {:a "a" :b [{:c 42}]} (coerce {:b [{}]}))))
+    (testing "nils are not punned"
+      (is (thrown? #?(:clj Exception :cljs js/Error) (coerce {:a nil}))))))
+
 (def optional-keys-schema
   {(s/optional-key :a) s/Str
    (s/required-key :b) s/Str


### PR DESCRIPTION
Fixes #25. This adds a separate matcher for adding missing keys – I thought that was the best thing for backwards compatibility.  I did rename `default-coercion-matcher`, though, to call attention to the difference between it and `default-key-matcher`.